### PR TITLE
Fix possible ArrayIndexOutOfBoundException

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java
+++ b/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java
@@ -173,7 +173,11 @@ public class RefinedSoundex implements StringEncoder {
         if (!Character.isLetter(c)) {
             return 0;
         }
-        return this.soundexMapping[Character.toUpperCase(c) - 'A'];
+        int index = Character.toUpperCase(c) - 'A';
+        if (index < 0 || index >= this.soundexMapping.length) {
+            return 0;
+        }
+        return this.soundexMapping[index];
     }
 
     /**


### PR DESCRIPTION
This fixes a possible ArrayIndexOutOfBoundException in [src/main/java/org/apache/commons/codec/language/RefinedSoundex.java](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/language/RefinedSoundex.java)

The `getMappingCode(char)` method takes in a random character and checks if it is a letter, then returns a mapping code from the `soundexMapping` array if it is a letter. But the checking contains a bug. The `Character.isLetter()` method will return true not only for English characters. For example, a char with character code 1689 will also make `Character.isLetter()` returns true. Using a character with large character code that passed the `Character.isLetter()` check and a way smaller `soundexMapping` array will cause ArrayIndexOutOfBoundException.

This PR adds a conditional checking to ensure the index is never out of bounds from the configured `soundexMapping` array. If the calculated index goes out of bounds, it will simply return 0, just like the original logic when Character.isLetter() returns false.

We found this bug using fuzzing by way of OSS-Fuzz. And this possible bug is reported at https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64353.