### PR TITLE
Fix possible StringIndexOutOfBoundException

### DIFF
--- a/src/main/java/org/apache/commons/codec/language/MatchRatingApproachEncoder.java
+++ b/src/main/java/org/apache/commons/codec/language/MatchRatingApproachEncoder.java
@@ -126,12 +126,27 @@ public class MatchRatingApproachEncoder implements StringEncoder {
         // Preprocessing
         name = cleanName(name);
 
+        // Bulletproof if name becomes empty after cleanName(name)
+        if (EMPTY.equalsIgnoreCase(name) || SPACE.equalsIgnoreCase(name) || name.length() == 0) {
+            return EMPTY;
+        }
+
         // BEGIN: Actual encoding part of the algorithm...
         // 1. Delete all vowels unless the vowel begins the word
         name = removeVowels(name);
 
+        // Bulletproof if name becomes empty after removeVowels(name)
+        if (EMPTY.equalsIgnoreCase(name) || SPACE.equalsIgnoreCase(name) || name.length() == 0) {
+            return EMPTY;
+        }
+
         // 2. Remove second consonant from any double consonant
         name = removeDoubleConsonants(name);
+
+        // Bulletproof if name becomes empty after removeDoubleConsonants(name)
+        if (EMPTY.equalsIgnoreCase(name) || SPACE.equalsIgnoreCase(name) || name.length() == 0) {
+            return EMPTY;
+        }
 
         // 3. Reduce codex to 6 letters by joining the first 3 and last 3 letters
         name = getFirst3Last3(name);


### PR DESCRIPTION
This fixes a possible StringIndexOutOfBoundException in [src/main/java/org/apache/commons/codec/language/MatchRatingApproachEncoder.java](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/language/MatchRatingApproachEncoder.java)

The `encode(String)` method takes in a random String and checks if it is empty. It will go through a few rounds of processing if the given String is not empty. It does contain a check to ensure the String is not empty before processing. But it has some missing checks. Each of the 3 processing methods `cleanName(name)` / `removeVowels(name)` / `removeDoubleConsonants(name)` remove some characters from the String and could cause the string to become empty (length = 0). And that results in StringIndexOutOfBoundException when `substring()` method is called in the next processing method. For example, if the randomly provided string is `..`, it gets past the first checking in the encode method and enters the `cleanName(name)` method. The `cleanName(name)` method removes the two dots and returns an empty string. Without the additional checking, it causes the StringIndexOutOfBoundException in the `substring()` method call in the next `removeVowels(name)` method call cause the length of the string is 0.

This PR adds some conditional checking to ensure the string is not empty after each method call. If it is empty after any method call, it will simply return `EMPTY` and avoid continuing processing onto the next processing method.

We found this bug using fuzzing by way of OSS-Fuzz. It is reported at https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64359.