### PR TITLE
Fix possible ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/apache/commons/codec/net/QuotedPrintableCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/QuotedPrintableCodec.java
@@ -208,6 +208,11 @@ public class QuotedPrintableCodec implements BinaryEncoder, BinaryDecoder, Strin
         final int bytesLength = bytes.length;
 
         if (strict) {
+            // Ensure bytes have at least 3 bytes
+            if (bytesLength < 3) {
+                return null;
+            }
+
             int pos = 1;
             // encode up to buffer.length - 3, the last three octets will be treated
             // separately for simplification of note #3


### PR DESCRIPTION
This fixes a possible ArrayIndexOutOfBoundException in [src/main/java/org/apache/commons/codec/language/QuotedPrintableCodec.java](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/language/QuotedPrintableCodec.java)

The `encodeQuotedPrintable()` method takes in a random byte array and processes it. If the provided `strict` boolean is true, it will go into the first branch. There is a for loop to loop through the byte array from the index 0 to the index byte.length - 3. The index is then used directly in `getUnsignedOctet` method If the length of the byte array is less than 3, it will result in a negative index and cause ArrayIndexOutOfBoundsException in `getUnsignedOctet()` method call.

This PR adds a conditional check to ensure the index is never negative. It will simply return null if the byte array is too short (with a length less than 3) if `strict` value is true.

We found this bug using fuzzing by way of OSS-Fuzz. It is reported at https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64358.