### PR TITLE
Fix possible IndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/apache/commons/codec/net/PercentCodec.java
+++ b/src/main/java/org/apache/commons/codec/net/PercentCodec.java
@@ -248,7 +248,10 @@ public class PercentCodec implements BinaryEncoder, BinaryDecoder {
     private void insertAlwaysEncodeChars(final byte[] alwaysEncodeCharsArray) {
         if (alwaysEncodeCharsArray != null) {
             for (final byte b : alwaysEncodeCharsArray) {
-                insertAlwaysEncodeChar(b);
+                // Skipping invalid bytes
+                if (b >= 0) {
+                    insertAlwaysEncodeChar(b);
+                }
             }
         }
         insertAlwaysEncodeChar(ESCAPE_CHAR);


### PR DESCRIPTION
This fixes a possible IndexOutOfBoundsException in [src/main/java/org/apache/commons/codec/net/PercentCodec.java](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/net/PercentCodec.java)

The `insertAlwaysEncodeChars()` method takes in a random byte array and processes it byte by byte. Each byte is passed to `insertAlwaysEncodeChar()` to set the corresponding bit in the BitSet object `alwaysEncodeChars` to true by calling the `set()` method of the BitSet object. As BitSet only accept positive index, if any byte is negative, it will cause IndexOutOfBoundsException when calling the `set()` method.

This PR adds a conditional check to ensure only valid bytes (positive or zero) are processed.

We found this bug using fuzzing by way of OSS-Fuzz. It is reported at https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64362.